### PR TITLE
Fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,3 @@ script:
 - npm run lint
 - npm run build
 - npm run test
-env:
-- NODE_ENV=testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ script:
 - npm run lint
 - npm run build
 - npm run test
+env:
+- NODE_ENV=testing

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc --strict --noImplicitReturns --noUnusedLocals --noUnusedParameters",
     "lint-staged": "lint-staged",
-    "test": "jest",
-    "test-watch": "jest --watch",
+    "test": "NODE_ENV= jest",
+    "test-watch": "NODE_ENV= jest --watch",
     "lint": "tslint -p . --force --format codeFrame; exit 0",
     "pretty": "prettier --parser typescript --write 'src/*.ts'",
     "precommit": "lint-staged && npm test",

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -170,7 +170,6 @@ test('silent stream does not write', () => {
             {
                 stream: new Writable({
                     write: (chunk, encoding, next) => {
-                        const json = JSON.parse(chunk);
                         loggerWrites();
                         next();
                     },


### PR DESCRIPTION
It is not documented but Travis uses NODE_ENV=test environment variable which caused cosmas not to write anything and thus failing most of the tests. This fixes it.

Also some tests were refactored in an effort to fix Travis problem.