### PR TITLE
Add logger name to default message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Added
 - coveralls integration
+- automatic logger name in stackdriver messages
   
 ## Changed
 - refactoring of express handlers

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,5 +8,5 @@ module.exports = {
     collectCoverage: true,
     // testURL because of problems with jsdom https://github.com/jsdom/jsdom/issues/2304
     testURL: "http://localhost",
-    setupFilesAfterEnv: ['<rootDir>/src/tests/setup.ts'],
+    setupFilesAfterEnv: ['jest-extended'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
     collectCoverage: true,
     // testURL because of problems with jsdom https://github.com/jsdom/jsdom/issues/2304
     testURL: "http://localhost",
+    setupFilesAfterEnv: ['<rootDir>/src/tests/setup.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -57,14 +57,15 @@
     "coveralls": "^3.0.2",
     "express": "^4.16.3",
     "husky": "^0.14.3",
-    "jest": "^23.6.0",
+    "jest": "^24.1.0",
+    "jest-extended": "^0.11.1",
     "lint-staged": "^7.3.0",
     "npm-check": "^5.9.0",
     "prettier": "^1.14.3",
     "supertest": "^3.1.0",
-    "ts-jest": "^23.10.4",
+    "ts-jest": "^24.0.0",
     "tslint": "^5.11.0",
     "tslint-config-ackee": "^0.2.5",
-    "typescript": "^3.1.3"
+    "typescript": "^3.3.3333"
   }
 }

--- a/src/stackdriver.ts
+++ b/src/stackdriver.ts
@@ -13,6 +13,9 @@ class StackDriverFormatStream extends Transform {
     // tslint:disable-next-line:function-name
     public _transform(chunk: any, _encoding: string, callback: (error?: Error | undefined, data?: any) => void) {
         const obj = JSON.parse(chunk);
+        if (obj.name) {
+            obj.message = `[${obj.name}] ${obj.message}`;
+        }
         obj.severity = PINO_TO_STACKDRIVER[obj.level] || 'UNKNOWN';
 
         this.push(`${JSON.stringify(obj)}\n`);

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,4 +1,5 @@
 import * as express from 'express';
+import 'jest-extended';
 import { Writable } from 'stream';
 import * as supertest from 'supertest';
 import { levels } from '../levels';
@@ -59,7 +60,7 @@ test('child logger has warning level', () =>
         loggerFactory({
             streams: [
                 testWriteStream(resolve, json => {
-                    expect(json.message).toBe('Hello');
+                    expect(json.message).toContain('Hello');
                     expect(json.level).toBe(levels.warn);
                 }),
             ],
@@ -182,3 +183,19 @@ test('silent stream does not write', () => {
     logger.fatal('Hello');
     expect(loggerWrites).not.toBeCalled();
 });
+
+test('logger name is shown in non-pretty message', () =>
+    new Promise((resolve, reject) => {
+        const loggerName = 'database';
+        loggerFactory({
+            streams: [
+                testWriteStream(resolve, json => {
+                    expect(json.name).toBe(loggerName);
+                    expect(json.message).toStartWith(`[${loggerName}] `);
+                }),
+            ],
+        });
+        const logger = loggerFactory(loggerName);
+
+        logger.fatal('Hello');
+    }));

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,1 @@
+import 'jest-extended';

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,1 +1,0 @@
-import 'jest-extended';


### PR DESCRIPTION
Automatically put logger name before the message, when using default (stackdriver optimized) logger.

Before:
`Some message`

Now:
`[Database] Some message`