### PR TITLE
🐛 Fix extend sentry import

### DIFF
--- a/sentry/index.d.ts
+++ b/sentry/index.d.ts
@@ -1,0 +1,7 @@
+import  { extendSentry } from '../dist/sentry'
+
+export default extendSentry
+
+declare module 'cosmas/sentry' {
+    export = extendSentry
+}

--- a/sentry/index.js
+++ b/sentry/index.js
@@ -1,0 +1,4 @@
+// This folder and this file is to simplify sentry include so you can import it
+// like so: import('cosmas/sentry') 
+
+module.exports.default = require('../dist/sentry').extendSentry


### PR DESCRIPTION
Docs say you should use `import extendSentry from 'cosmas/sentry'`,
but this doesnt work due to missing types and code alike.

This fix adds missing types and code to make the beautifully
designed and documented interface work.
