### PR TITLE
⚡️ Update transform stream to parse only on pretty

### DIFF
--- a/src/streams.ts
+++ b/src/streams.ts
@@ -8,16 +8,12 @@ const getDefaultTransformStream = (options: CosmasOptions & { messageKey: string
     class DefaultTransformStream extends Transform {
         // tslint:disable-next-line:function-name
         public _transform(chunk: any, _encoding: string, callback: TransformCallback) {
-            const obj = JSON.parse(chunk);
-            let res;
-
             if (options.pretty) {
-                res = util.inspect(obj, { colors: true, showHidden: true, depth: Infinity });
+                const res = util.inspect(JSON.parse(chunk), { colors: true, showHidden: true, depth: Infinity });
+                this.push(`${res}\n`);
             } else {
-                res = JSON.stringify(obj);
+                this.push(chunk);
             }
-
-            this.push(`${res}\n`);
             callback();
         }
     }


### PR DESCRIPTION
TLDR; Remove `JSON.parse`/`JSON.stringify` in main transform stream,
when the `pretty` option is disabled.

**Context**

Using cosmas we had several issues with OOM during logging. The issue
can be reproduced with the following snippet:

```js
const message = { text: '.'.repeat(4e6) }
mb = (s) => `${((encodeURI(s).split(/%..|./).length - 1)/2**20).toFixed(2)} MB`

// --> 3.81 MB (node index.js, crashes with the 20 MB limit as cosmas)
// console.log(mb(JSON.stringify(message)))

// OOM (node --max-old-space-size=20 index.js) (20 MB)
require('cosmas').default({}).info(message)

// OK (node --max-old-space-size=20 index.js)
require('pino').default().info(message)
```
```
    "cosmas": "^3.0.7",
    "pino": "^7.4.0"
```

While the pino logger logs the thing without issues, cosmas log crashes.

This is caused by `JSON.parse`/`JSON.stringify`, which has surprisingly demanding memory
requirements (20 MB insufficient for stringifying 4 MB JSON). This pair
of functions is used in the main transform stream. The only utility now
is that it allows for `pretty` option, where `inspect` is used, however
it bubbles through both functions even if you don't need it (effectively
just adding a newline to the output).

Now the parsing/stringifying is only applied when `pretty` option is used.
It is assumed that it will only be used on dev environment, where
logging large data should not be an issue regarding memory safety.

After the change, all the tests pass and the snippet no longer crashes
on OOM.